### PR TITLE
setq needs more than one argument

### DIFF
--- a/picolisp.el
+++ b/picolisp.el
@@ -147,7 +147,7 @@
 
   ;; This is just to avoid tabsize-variations fuck-up.
   (make-local-variable 'indent-tabs-mode)
-  (setq indent-tabs-mode)
+  (setq indent-tabs-mode nil)
 
   (setq dabbrev-case-fold-search t)
   (setq dabbrev-case-replace nil)


### PR DESCRIPTION
With Emacs 25.1 (maybe this was happening also in an earlier version), I encounter the following error without this patch.
```
Debugger entered--Lisp error: (wrong-number-of-arguments setq 1)
  (setq indent-tabs-mode)
  ...
```
It seems as if earlier versions of Emacs Lisp were more forgiving(?).  :)