### PR TITLE
make package.el's package-buffer-info happy

### DIFF
--- a/picolisp.el
+++ b/picolisp.el
@@ -1,4 +1,4 @@
-;;; picolisp-mode --- Major mode to edit picoLisp.
+;;; picolisp.el --- Major mode to edit picoLisp.
 ;; Version: 1.3
 
 ;; Copyright (c) 2009, Guillermo R. Palavecino
@@ -761,3 +761,5 @@ The main differences are:
    (font-lock-add-keywords 'inferior-picolisp-mode tsm-lock) ) ) 
 
 (provide 'picolisp)
+
+;;; picolisp.el ends here


### PR DESCRIPTION
@tj64 Thorsten, hi! 

I'm using an emacs package manager (`elpaso`) which eventually calls `package.el` bits.  It failed to install `picolisp-mode`, because a function in `package.el` (called `package-buffer-info` and in the call stack) could not validate some `picolisp.el` comments as having the correct format.

To fix this, I changed as little as possible to `picolisp.el` (and I changed and added comments only -- no code) so that `picolisp-mode` package could be installed successfully.

I hope you will accept this PR; however, there is no rush, as I am having `elpaso` install `picolisp-mode` from my clone now.  Thanks, as always!  Rick