### PR TITLE
Fix Homepage header and add SPDX-License-Identifier header

### DIFF
--- a/picolisp.el
+++ b/picolisp.el
@@ -8,6 +8,7 @@
 ;;          Thorsten Jolitz
 ;; Keywords: emacs picolisp
 ;; Homepage: https://github.com/tj64/picolisp-mode
+;; SPDX-License-Identifier: GPL-2.0-or-later
 
 ;; This file is NOT part of GNU emacs.
 

--- a/picolisp.el
+++ b/picolisp.el
@@ -7,7 +7,7 @@
 ;; Authors: Guillermo R. Palavecino
 ;;          Thorsten Jolitz
 ;; Keywords: emacs picolisp
-;; Homepage: https://orgmode.org
+;; Homepage: https://github.com/tj64/picolisp-mode
 
 ;; This file is NOT part of GNU emacs.
 


### PR DESCRIPTION
There is already a permission statement in the library commentary, but
tools such as those used by the Emacsmirror, won't find it because it
diverges from the standard format.